### PR TITLE
Zcu102

### DIFF
--- a/components/SerialServer/include/plat/zynqmp/plat/serial.h
+++ b/components/SerialServer/include/plat/zynqmp/plat/serial.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019, Data61
+ * Commonwealth Scientific and Industrial Research Organisation (CSIRO)
+ * ABN 41 687 119 230.
+ *
+ * This software may be distributed and modified according to the terms of
+ * the BSD 2-Clause license. Note that NO WARRANTY is provided.
+ * See "LICENSE_BSD2.txt" for details.
+ *
+ * @TAG(DATA61_BSD)
+ */
+#pragma once
+
+#define HARDWARE_SERIAL_INTERFACES                              \
+    emits Dummy dummy_source;                                   \
+    consumes Dummy serial_dev;
+
+#define HARDWARE_SERIAL_ATTRIBUTES
+
+#define HARDWARE_SERIAL_COMPOSITION                                                     \
+        connection seL4DTBHardware serial_conn(from dummy_source, to serial_dev);
+
+#define HARDWARE_SERIAL_CONFIG                                      \
+        serial_dev.dtb = dtb({"path" : "/amba/serial@ff000000"});   \
+        serial_dev.generate_interrupts = 1;

--- a/components/SerialServer/src/plat/zynqmp/plat.c
+++ b/components/SerialServer/src/plat/zynqmp/plat.c
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019, Data61
+ * Commonwealth Scientific and Industrial Research Organisation (CSIRO)
+ * ABN 41 687 119 230.
+ *
+ * This software may be distributed and modified according to the terms of
+ * the BSD 2-Clause license. Note that NO WARRANTY is provided.
+ * See "LICENSE_BSD2.txt" for details.
+ *
+ * @TAG(DATA61_BSD)
+ */
+
+#include <autoconf.h>
+#include <sel4/sel4.h>
+#include <camkes.h>
+#include <utils/util.h>
+#include <platsupport/irq.h>
+#include <sel4utils/sel4_zf_logif.h>
+
+#include "../../plat.h"
+#include "../../serial.h"
+
+void plat_post_init(ps_irq_ops_t *irq_ops)
+{
+    ps_irq_t irq_info = { .type = PS_INTERRUPT, .irq = { .number = DEFAULT_SERIAL_INTERRUPT }};
+    irq_id_t serial_irq_id = ps_irq_register(irq_ops, irq_info, serial_server_irq_handle, NULL);
+    ZF_LOGF_IFERR(serial_irq_id < 0, "Failed to register irq for serial");
+}

--- a/components/SerialServer/src/serial.c
+++ b/components/SerialServer/src/serial.c
@@ -69,39 +69,45 @@ static int num_getchar_clients = 0;
 static getchar_client_t *getchar_clients = NULL;
 
 /* We predefine output colours for clients */
-const char *all_output_colours[MAX_CLIENTS * 2] = {
-    /* Processed streams */
-    ANSI_COLOR(RED),
-    ANSI_COLOR(GREEN),
-    ANSI_COLOR(BLUE),
-    ANSI_COLOR(MAGENTA),
-    ANSI_COLOR(YELLOW),
-    ANSI_COLOR(CYAN),
-    ANSI_COLOR(RED, BOLD)
-    ANSI_COLOR(GREEN, BOLD),
-    ANSI_COLOR(BLUE, BOLD),
-    ANSI_COLOR(MAGENTA, BOLD),
-    ANSI_COLOR(YELLOW, BOLD),
-    ANSI_COLOR(CYAN, BOLD),
-
-    /* Raw streams */
-    ANSI_COLOR2(RED, WHITE),
-    ANSI_COLOR2(GREEN, WHITE),
-    ANSI_COLOR2(BLUE, WHITE),
-    ANSI_COLOR2(MAGENTA, WHITE),
-    ANSI_COLOR2(YELLOW, WHITE),
-    ANSI_COLOR2(CYAN, WHITE),
-    ANSI_COLOR2(RED, WHITE, BOLD)
-    ANSI_COLOR2(GREEN, WHITE, BOLD),
-    ANSI_COLOR2(BLUE, WHITE, BOLD),
-    ANSI_COLOR2(MAGENTA, WHITE, BOLD),
-    ANSI_COLOR2(YELLOW, WHITE, BOLD),
-    ANSI_COLOR2(CYAN, WHITE, BOLD),
+const char *all_output_colours[2][MAX_CLIENTS] = {
+    {
+        /* Processed streams */
+        ANSI_COLOR(RED),
+        ANSI_COLOR(GREEN),
+        ANSI_COLOR(BLUE),
+        ANSI_COLOR(MAGENTA),
+        ANSI_COLOR(YELLOW),
+        ANSI_COLOR(CYAN),
+        ANSI_COLOR(RED, BOLD)
+        ANSI_COLOR(GREEN, BOLD),
+        ANSI_COLOR(BLUE, BOLD),
+        ANSI_COLOR(MAGENTA, BOLD),
+        ANSI_COLOR(YELLOW, BOLD),
+        ANSI_COLOR(CYAN, BOLD),
+    },
+    {
+        /* Raw streams */
+        ANSI_COLOR2(RED, WHITE),
+        ANSI_COLOR2(GREEN, WHITE),
+        ANSI_COLOR2(BLUE, WHITE),
+        ANSI_COLOR2(MAGENTA, WHITE),
+        ANSI_COLOR2(YELLOW, WHITE),
+        ANSI_COLOR2(CYAN, WHITE),
+        ANSI_COLOR2(RED, WHITE, BOLD)
+        ANSI_COLOR2(GREEN, WHITE, BOLD),
+        ANSI_COLOR2(BLUE, WHITE, BOLD),
+        ANSI_COLOR2(MAGENTA, WHITE, BOLD),
+        ANSI_COLOR2(YELLOW, WHITE, BOLD),
+        ANSI_COLOR2(CYAN, WHITE, BOLD),
+    },
 };
+
+#define COLOUR_INDEX_TO_STYLE(x) ((x) / (MAX_CLIENTS - 1))
+#define COLOUR_INDEX_TO_SLOT(x)  ((x) % MAX_CLIENTS)
 
 static void flush_buffer(int b)
 {
-    const char *col = all_output_colours[b];
+    const char *col = all_output_colours[COLOUR_INDEX_TO_STYLE(b)][COLOUR_INDEX_TO_SLOT(b)];
     int i;
     if (output_buffers_used[b] == 0) {
         return;
@@ -148,7 +154,7 @@ static bool flush_buffer_line(int b)
         return 0;
     }
     if (b != last_out) {
-        printf("%s%s", COLOR_RESET, all_output_colours[b]);
+        printf("%s%s", COLOR_RESET, all_output_colours[COLOUR_INDEX_TO_STYLE(b)][COLOUR_INDEX_TO_SLOT(b)]);
         last_out = b;
     }
     int i;
@@ -288,7 +294,7 @@ static void internal_putchar(int b, int c)
          * it's probably going to overflow again, so let's avoid
          * that. */
         if (last_out != b) {
-            printf("%s%s", COLOR_RESET, all_output_colours[b]);
+            printf("%s%s", COLOR_RESET, all_output_colours[COLOUR_INDEX_TO_STYLE(b)][COLOUR_INDEX_TO_SLOT(b)]);
             last_out = b;
         }
     } else if ((index >= 1 && is_newline(buffer + index - 1) && coalesce_status == -1)

--- a/components/TimeServer/include/plat/zynqmp/plat/timers.h
+++ b/components/TimeServer/include/plat/zynqmp/plat/timers.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019, Data61
+ * Commonwealth Scientific and Industrial Research Organisation (CSIRO)
+ * ABN 41 687 119 230.
+ *
+ * This software may be distributed and modified according to the terms of
+ * the BSD 2-Clause license. Note that NO WARRANTY is provided.
+ * See "LICENSE_BSD2.txt" for details.
+ *
+ * @TAG(DATA61_BSD)
+ */
+#pragma once
+
+#define HARDWARE_TIMER_INTERFACES                                                   \
+    emits Dummy dummy_source;                                                       \
+    consumes Dummy ttc0;                                                            \
+    consumes Dummy ttc1;
+#define HARDWARE_TIMER_ATTRIBUTES
+#define HARDWARE_TIMER_COMPOSITION                                                      \
+        connection seL4DTBHardware ttc0_conn(from dummy_source, to ttc0);               \
+        connection seL4DTBHardware ttc1_conn(from dummy_source, to ttc1);
+#define HARDWARE_TIMER_CONFIG                                                       \
+        ttc0.dtb = dtb({"path" : "/amba/timer@ff110000"});                          \
+        ttc0.generate_interrupts = 1;                                               \
+        ttc1.dtb = dtb({"path" : "/amba/timer@ff120000"});                          \
+        ttc1.generate_interrupts = 1;
+#define HARDWARE_TIMER_PLAT_INTERFACES

--- a/interfaces/global-connectors.camkes
+++ b/interfaces/global-connectors.camkes
@@ -102,7 +102,7 @@ connector seL4RPCCallDataport {
  * <from_interface>_num_badges()
  */
 connector seL4RPCDataport {
-    from Procedures template "seL4RPCDataport-from.template.c";
+    from Procedures template "seL4RPCDataport-from.template.c" with 0 threads;
     to Procedure template "seL4RPCDataport-to.template.c";
 }
 


### PR DESCRIPTION
These commits add serial and time server support for the zcu102. Without the util libs commits, the time server will work for ~38 seconds, and the serial server will function, but the interrupt will never actually be cleared in hardware. 

I also added a couple bug fix commits and remove some failed assertions and fix the output colors.