### PR TITLE
this is not the right way of doing this, need an imx8 generic platform

### DIFF
--- a/components/SerialServer/include/plat/imx8mm-evk/plat/serial.h
+++ b/components/SerialServer/include/plat/imx8mm-evk/plat/serial.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019, Data61
+ * Commonwealth Scientific and Industrial Research Organisation (CSIRO)
+ * ABN 41 687 119 230.
+ *
+ * This software may be distributed and modified according to the terms of
+ * the BSD 2-Clause license. Note that NO WARRANTY is provided.
+ * See "LICENSE_BSD2.txt" for details.
+ *
+ * @TAG(DATA61_BSD)
+ */
+#pragma once
+
+#define HARDWARE_SERIAL_INTERFACES                              \
+    emits Dummy dummy_source;                                   \
+    consumes Dummy serial_dev;
+
+#define HARDWARE_SERIAL_ATTRIBUTES
+
+#define HARDWARE_SERIAL_COMPOSITION                                                 \
+        connection seL4DTBHardware serial_conn(from dummy_source, to serial_dev);
+
+#define HARDWARE_SERIAL_CONFIG                                  \
+        serial_dev.dtb = dtb({"path":"/serial@30860000"});  \
+        serial_dev.generate_interrupts = 1;

--- a/components/SerialServer/src/plat/imx8mm-evk/plat.c
+++ b/components/SerialServer/src/plat/imx8mm-evk/plat.c
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019, Data61
+ * Commonwealth Scientific and Industrial Research Organisation (CSIRO)
+ * ABN 41 687 119 230.
+ *
+ * This software may be distributed and modified according to the terms of
+ * the BSD 2-Clause license. Note that NO WARRANTY is provided.
+ * See "LICENSE_BSD2.txt" for details.
+ *
+ * @TAG(DATA61_BSD)
+ */
+
+#include <autoconf.h>
+#include <sel4/sel4.h>
+#include <camkes.h>
+#include <utils/util.h>
+#include <platsupport/irq.h>
+#include <sel4utils/sel4_zf_logif.h>
+
+#include "../../plat.h"
+#include "../../serial.h"
+
+void plat_post_init(ps_irq_ops_t *irq_ops)
+{
+    ps_irq_t irq_info = { .type = PS_INTERRUPT, .irq = { .number = DEFAULT_SERIAL_INTERRUPT }};
+    irq_id_t serial_irq_id = ps_irq_register(irq_ops, irq_info, serial_server_irq_handle, NULL);
+    ZF_LOGF_IFERR(serial_irq_id < 0, "Failed to register irq for serial");
+}

--- a/components/TimeServer/include/plat/imx8mm-evk/plat/timers.h
+++ b/components/TimeServer/include/plat/imx8mm-evk/plat/timers.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019, Data61
+ * Commonwealth Scientific and Industrial Research Organisation (CSIRO)
+ * ABN 41 687 119 230.
+ *
+ * This software may be distributed and modified according to the terms of
+ * the BSD 2-Clause license. Note that NO WARRANTY is provided.
+ * See "LICENSE_BSD2.txt" for details.
+ *
+ * @TAG(DATA61_BSD)
+ */
+#pragma once
+
+#define HARDWARE_TIMER_INTERFACES                                                   \
+    consumes Dummy gpt1;                                                           \
+    consumes Dummy gpt2;                                                             \
+    emits Dummy dummy_source;
+#define HARDWARE_TIMER_ATTRIBUTES
+#define HARDWARE_TIMER_COMPOSITION                                                  \
+        connection seL4DTBHardware gpt_conn1(from dummy_source, to gpt1);         \
+        connection seL4DTBHardware gpt_conn2(from dummy_source, to gpt2);
+#define HARDWARE_TIMER_CONFIG                                                                       \
+        gpt1.dtb = dtb({"path" : "/gpt@302d0000"});                           \
+        gpt1.generate_interrupts = 1;                                                              \
+        gpt2.dtb = dtb({"path" : "/gpt@302e0000"});                              \
+        gpt2.generate_interrupts = 1;
+#define HARDWARE_TIMER_PLAT_INTERFACES


### PR DESCRIPTION
Tested the following on the imx8mm-evk board, tests work.
Need to look at a better way of using the shared imx8 hardware components in the cmake scripts.
I suggest not merging this as it is just a copy of the imx8mq-evk code.