### PR TITLE
seL4GlobalAsynch: add missing header

### DIFF
--- a/global-connectors.cmake
+++ b/global-connectors.cmake
@@ -12,133 +12,116 @@ CAmkESAddImportPath(interfaces plat_interfaces/${KernelPlatform})
 CAmkESAddTemplatesPath(templates)
 
 # Connector templates with FROM and TO only
-foreach(connector IN ITEMS seL4GlobalAsynchCallback seL4MessageQueue
-                           seL4RPCOverMultiSharedData
-)
-    DeclareCAmkESConnector(
-        ${connector} FROM ${connector}-from.template.c TO ${connector}-to.template.c
-    )
+foreach(connector IN ITEMS seL4GlobalAsynchCallback seL4MessageQueue seL4RPCOverMultiSharedData)
+  DeclareCAmkESConnector(${connector} FROM ${connector}-from.template.c TO
+                         ${connector}-to.template.c)
 endforeach()
 
 # Connector templates with FROM, FROM_HEADER, TO and TO_HEADER
 foreach(connector IN ITEMS seL4RPCCallSignal seL4RPCDataport seL4RPCDataportSignal seL4RPCNoThreads
-                           seL4GPIOServer seL4Ethdriver
-)
-    DeclareCAmkESConnector(
-        ${connector}
-        FROM
-        ${connector}-from.template.c
-        FROM_HEADER
-        ${connector}-from.template.h
-        TO
-        ${connector}-to.template.c
-        TO_HEADER
-        ${connector}-to.template.h
-    )
+                           seL4GPIOServer seL4Ethdriver)
+  DeclareCAmkESConnector(
+    ${connector}
+    FROM
+    ${connector}-from.template.c
+    FROM_HEADER
+    ${connector}-from.template.h
+    TO
+    ${connector}-to.template.c
+    TO_HEADER
+    ${connector}-to.template.h)
 endforeach()
 
 # Specific connector templates not fitting with the schemes above
-DeclareCAmkESConnector(
-    seL4SharedDataWithCaps FROM seL4SharedDataWithCaps.template.c TO
-    seL4SharedDataWithCaps.template.c
-)
+DeclareCAmkESConnector(seL4SharedDataWithCaps FROM seL4SharedDataWithCaps.template.c TO
+                       seL4SharedDataWithCaps.template.c)
 
 DeclareCAmkESConnector(
-    seL4GlobalAsynch
-    FROM
-    seL4GlobalAsynch-from.template.c
-    FROM_HEADER
-    seL4GlobalAsynch-from.template.h
-    TO
-    seL4GlobalAsynch-to.template.c
-)
+  seL4GlobalAsynch
+  FROM
+  seL4GlobalAsynch-from.template.c
+  FROM_HEADER
+  seL4GlobalAsynch-from.template.h
+  TO
+  seL4GlobalAsynch-to.template.c)
 
 DeclareCAmkESConnector(
-    seL4TimeServer
-    FROM
-    seL4RPCCallSignal-from.template.c
-    FROM_HEADER
-    seL4RPCCallSignal-from.template.h
-    TO
-    seL4RPCCallSignal-to.template.c
-    TO_HEADER
-    seL4RPCCallSignal-to.template.h
-)
+  seL4TimeServer
+  FROM
+  seL4RPCCallSignal-from.template.c
+  FROM_HEADER
+  seL4RPCCallSignal-from.template.h
+  TO
+  seL4RPCCallSignal-to.template.c
+  TO_HEADER
+  seL4RPCCallSignal-to.template.h)
 
 DeclareCAmkESConnector(
-    seL4SerialServer
-    FROM
-    seL4RPCDataportSignal-from.template.c
-    FROM_HEADER
-    seL4RPCDataportSignal-from.template.h
-    TO
-    seL4RPCDataportSignal-to.template.c
-)
+  seL4SerialServer
+  FROM
+  seL4RPCDataportSignal-from.template.c
+  FROM_HEADER
+  seL4RPCDataportSignal-from.template.h
+  TO
+  seL4RPCDataportSignal-to.template.c)
 
 DeclareCAmkESConnector(
-    seL4RPCCallSignalNoThreads
-    FROM
-    seL4RPCCallSignal-from.template.c
-    FROM_HEADER
-    seL4RPCCallSignal-from.template.h
-    TO
-    seL4RPCCallSignal-to.template.c
-    TO_HEADER
-    seL4RPCCallSignal-to.template.h
-)
+  seL4RPCCallSignalNoThreads
+  FROM
+  seL4RPCCallSignal-from.template.c
+  FROM_HEADER
+  seL4RPCCallSignal-from.template.h
+  TO
+  seL4RPCCallSignal-to.template.c
+  TO_HEADER
+  seL4RPCCallSignal-to.template.h)
 
 DeclareCAmkESConnector(
-    seL4PicoServerSignal
-    FROM
-    seL4RPCCallSignal-from.template.c
-    FROM_HEADER
-    seL4RPCCallSignal-from.template.h
-    TO
-    seL4RPCCallSignal-to.template.c
-    TO_HEADER
-    seL4RPCCallSignal-to.template.h
-)
+  seL4PicoServerSignal
+  FROM
+  seL4RPCCallSignal-from.template.c
+  FROM_HEADER
+  seL4RPCCallSignal-from.template.h
+  TO
+  seL4RPCCallSignal-to.template.c
+  TO_HEADER
+  seL4RPCCallSignal-to.template.h)
 
 DeclareCAmkESConnector(
-    seL4RPCDataportNoThreads
-    FROM
-    seL4RPCDataport-from.template.c
-    FROM_HEADER
-    seL4RPCDataport-from.template.h
-    TO
-    seL4RPCDataport-to.template.c
-    TO_HEADER
-    seL4RPCDataport-to.template.h
-)
+  seL4RPCDataportNoThreads
+  FROM
+  seL4RPCDataport-from.template.c
+  FROM_HEADER
+  seL4RPCDataport-from.template.h
+  TO
+  seL4RPCDataport-to.template.c
+  TO_HEADER
+  seL4RPCDataport-to.template.h)
 
 DeclareCAmkESConnector(
-    seL4PicoServer
-    FROM
-    seL4RPCDataport-from.template.c
-    FROM_HEADER
-    seL4RPCDataport-from.template.h
-    TO
-    seL4RPCDataport-to.template.c
-    TO_HEADER
-    seL4RPCDataport-to.template.h
-)
+  seL4PicoServer
+  FROM
+  seL4RPCDataport-from.template.c
+  FROM_HEADER
+  seL4RPCDataport-from.template.h
+  TO
+  seL4RPCDataport-to.template.c
+  TO_HEADER
+  seL4RPCDataport-to.template.h)
 
-DeclareCAmkESConnector(
-    seL4GlobalAsynchHardwareInterrupt TO seL4GlobalAsynchHardwareInterrupt.template.c
-)
+DeclareCAmkESConnector(seL4GlobalAsynchHardwareInterrupt TO
+                       seL4GlobalAsynchHardwareInterrupt.template.c)
 
-DeclareCAmkESConnector(
-    seL4DTBHardwareThreadless FROM empty.c TO seL4DTBHardwareThreadless.template.c
-)
+DeclareCAmkESConnector(seL4DTBHardwareThreadless FROM empty.c TO
+                       seL4DTBHardwareThreadless.template.c)
 
 DeclareCAmkESConnector(seL4DTBHWThreadless TO seL4DTBHardwareThreadless.template.c)
 
 DeclareCAmkESConnector(
-    seL4VirtQueues
-    FROM
-    seL4VirtQueues-from.template.c
-    FROM_HEADER
-    seL4VirtQueues-from.template.h
-    TO
-    empty.c
-)
+  seL4VirtQueues
+  FROM
+  seL4VirtQueues-from.template.c
+  FROM_HEADER
+  seL4VirtQueues-from.template.h
+  TO
+  empty.c)

--- a/global-connectors.cmake
+++ b/global-connectors.cmake
@@ -12,7 +12,7 @@ CAmkESAddImportPath(interfaces plat_interfaces/${KernelPlatform})
 CAmkESAddTemplatesPath(templates)
 
 # Connector templates with FROM and TO only
-foreach(connector IN ITEMS seL4GlobalAsynch seL4GlobalAsynchCallback seL4MessageQueue
+foreach(connector IN ITEMS seL4GlobalAsynchCallback seL4MessageQueue
                            seL4RPCOverMultiSharedData
 )
     DeclareCAmkESConnector(
@@ -41,6 +41,16 @@ endforeach()
 DeclareCAmkESConnector(
     seL4SharedDataWithCaps FROM seL4SharedDataWithCaps.template.c TO
     seL4SharedDataWithCaps.template.c
+)
+
+DeclareCAmkESConnector(
+    seL4GlobalAsynch
+    FROM
+    seL4GlobalAsynch-from.template.c
+    FROM_HEADER
+    seL4GlobalAsynch-from.template.h
+    TO
+    seL4GlobalAsynch-to.template.c
 )
 
 DeclareCAmkESConnector(

--- a/templates/seL4GlobalAsynch-from.template.h
+++ b/templates/seL4GlobalAsynch-from.template.h
@@ -1,0 +1,7 @@
+/*
+ * Copyright 2026, Proofcraft Pty Ltd
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+void /*? me.interface.name ?*/_emit_underlying(void);


### PR DESCRIPTION
The `*_emit_underlying` functions were previously not declared in any header, but can used in user code (e.g. in crossvm_init.c in vm-examples). This previously worked, because earlier versions of gcc allowed implicit function declarations.

Add the missing header for seL4GlobalAsynch and declare the function there.

Together with https://github.com/seL4/projects_libs/pull/26 and https://github.com/seL4/camkes-vm-examples/pull/98, this should now fix the CAmkES vm-examples build for armv7.

Test with: https://github.com/seL4/projects_libs/pull/26 and https://github.com/seL4/camkes-vm-examples/pull/98